### PR TITLE
Radiance accumulation and propagation kerenels; Bug fixes

### DIFF
--- a/apps/neural_radiance_caching_mdl/CMakeLists.txt
+++ b/apps/neural_radiance_caching_mdl/CMakeLists.txt
@@ -31,6 +31,8 @@ cmake_minimum_required(VERSION 3.17)
 project( neural_radiance_caching_mdl )
 message("\nPROJECT_NAME = " "${PROJECT_NAME}")
 
+set (CMAKE_CXX_STANDARD 20)
+
 find_package(OpenGL REQUIRED)
 find_package(GLFW REQUIRED)
 find_package(GLEW REQUIRED)
@@ -182,6 +184,7 @@ set( SHADERS
 set( KERNELS
   # Native CUDA kernels
   ${CMAKE_CURRENT_SOURCE_DIR}/shaders/compositor.cu
+  ${CMAKE_CURRENT_SOURCE_DIR}/shaders/nrc_helpers.cu
 )
 
 set( SHADERS_HEADERS
@@ -225,7 +228,7 @@ NVCUDA_COMPILE_MODULE(
   TARGET_PATH "${MODULE_TARGET_DIR}/neural_radiance_caching_mdl_core"
   EXTENSION ".ptx"
   GENERATED_FILES KERNEL_MODULES
-  NVCC_OPTIONS "--ptx" "--machine=64" "--gpu-architecture=compute_50" "--use_fast_math" "--relocatable-device-code=true" "--generate-line-info" "-Wno-deprecated-gpu-targets" "-I${CMAKE_CURRENT_SOURCE_DIR}/shaders"
+  NVCC_OPTIONS "--ptx" "--machine=64" "--gpu-architecture=compute_50" "--use_fast_math" "--relocatable-device-code=true" "--generate-line-info" "-Wno-deprecated-gpu-targets" "-I${OPTIX_INCLUDE_DIR}" "-I${MDL_SDK_INCLUDE_DIRS}" "-I${CMAKE_CURRENT_SOURCE_DIR}/shaders"
 )
 
 source_group( "imgui"           FILES ${IMGUI} )
@@ -233,6 +236,7 @@ source_group( "nvpro_math"      FILES ${NVPRO_MATH} )
 source_group( "headers"         FILES ${HEADERS} )
 source_group( "sources"         FILES ${SOURCES} )
 source_group( "shaders"         FILES ${SHADERS} )
+source_group( "kernels"         FILES ${KERNELS} )
 source_group( "shaders_headers" FILES ${SHADERS_HEADERS} )
 source_group( "prg"             FILES ${PROGRAM_MODULES} )
 source_group( "ptx"             FILES ${KERNEL_MODULES} )
@@ -272,6 +276,7 @@ add_executable( neural_radiance_caching_mdl
   ${SOURCES}
   ${SHADERS_HEADERS}
   ${SHADERS}
+  ${KERNELS}
   ${PROGRAM_MODULES}
   ${KERNEL_MODULES}
 )

--- a/apps/neural_radiance_caching_mdl/inc/Device.h
+++ b/apps/neural_radiance_caching_mdl/inc/Device.h
@@ -572,7 +572,7 @@ public:
 	SystemData m_systemData{
 		// Static Data ==========
 		// This contains the root traversable handle as well.
-		.resolution     = {1, 1},
+		.resolution     = {2, 2},
 		.pathLengths    = {2, 5},
 		.walkLength     = 1,
 		.sceneEpsilon   = 500.0f * SCENE_EPSILON_SCALE,
@@ -611,8 +611,9 @@ public:
 
 	// A single module contains all the helper functions below.
 	CUmodule    m_moduleNRCHelpers{};
-	CUfunction  m_fnAccumulateRenderRadiance{};
 	CUfunction  m_fnPlaceholder{};
+	CUfunction  m_fnAccumulateRenderRadiance{},
+				m_fnPropagateTrainRadiance{};
 
 
 #if USE_FP32_OUTPUT

--- a/apps/neural_radiance_caching_mdl/shaders/neural_radiance_caching.h
+++ b/apps/neural_radiance_caching_mdl/shaders/neural_radiance_caching.h
@@ -53,7 +53,7 @@ namespace nrc
 		// 4 byte alignment
 
 		// Start of the radiance propagation chain. 
-		// Index into ControlBlock::trainingRecords, ::trainingRadianceTargets
+		// Index into ControlBlock::trainingRecords to get the train record to prop radiance to
 		int startTrainRecord/* = TRAIN_RECORD_INDEX_NONE*/;
 
 		// Used to mask off queried radiance for unbiased rays.

--- a/apps/neural_radiance_caching_mdl/shaders/nrc_helpers.cu
+++ b/apps/neural_radiance_caching_mdl/shaders/nrc_helpers.cu
@@ -1,0 +1,36 @@
+#include "config.h"
+
+#include <optix.h>
+
+#include "system_data.h"
+#include "compositor_data.h"
+#include "vector_math.h"
+
+// NOTE: This is a separate copy of sys data from the one managed by Optix.
+extern "C" __constant__ SystemData sysData;
+
+extern "C" __global__ void placeholder() { return; }
+
+// Radiance accumulator kernel to add the radiance * throughput 
+// at the end of the rendering paths to the output buffer.
+extern "C" __global__ void accumulate_render_radiance(float3 *lastRadiance, float3 *lastThroughput)
+{
+	const unsigned int xLaunch = blockDim.x * blockIdx.x + threadIdx.x; // [0..resolution.x)
+	const unsigned int yLaunch = blockDim.y * blockIdx.y + threadIdx.y; // [0..resolution.y)
+	if (xLaunch >= sysData.resolution.x || yLaunch >= sysData.resolution.y)
+	{
+		return;
+	}
+
+	const unsigned int index = yLaunch * sysData.resolution.x + xLaunch;
+	const auto buffer = reinterpret_cast<float4*>(sysData.outputBuffer);
+	
+	const float3 radiance = lastThroughput[index] * lastRadiance[index];
+	//const float3 radiance = lastThroughput[index];
+	//const float3 radiance = lastRadiance[index];
+	const float accWeight = 1.0f / float(sysData.pf.iterationIndex + 1);
+	
+	float3 dst = make_float3(buffer[index]);
+	dst += (radiance * accWeight);	
+	buffer[index] = make_float4(dst, 1.0f);
+}

--- a/apps/neural_radiance_caching_mdl/shaders/nrc_helpers.cu
+++ b/apps/neural_radiance_caching_mdl/shaders/nrc_helpers.cu
@@ -3,34 +3,83 @@
 #include <optix.h>
 
 #include "system_data.h"
-#include "compositor_data.h"
+#include "neural_radiance_caching.h"
 #include "vector_math.h"
+
 
 // NOTE: This is a separate copy of sys data from the one managed by Optix.
 extern "C" __constant__ SystemData sysData;
 
 extern "C" __global__ void placeholder() { return; }
 
+namespace {
+
+__forceinline__ __device__ uint2 getLaunchIndex()
+{
+	return { blockDim.x * blockIdx.x + threadIdx.x, 
+			 blockDim.y * blockIdx.y + threadIdx.y };
+}
+
+
+}
+
 // Radiance accumulator kernel to add the radiance * throughput 
 // at the end of the rendering paths to the output buffer.
-extern "C" __global__ void accumulate_render_radiance(float3 *lastRadiance, float3 *lastThroughput)
+extern "C" __global__ void accumulate_render_radiance(float3 *endRenderRadiance, float3 *endRenderThroughput)
 {
-	const unsigned int xLaunch = blockDim.x * blockIdx.x + threadIdx.x; // [0..resolution.x)
-	const unsigned int yLaunch = blockDim.y * blockIdx.y + threadIdx.y; // [0..resolution.y)
-	if (xLaunch >= sysData.resolution.x || yLaunch >= sysData.resolution.y)
-	{
-		return;
-	}
-
-	const unsigned int index = yLaunch * sysData.resolution.x + xLaunch;
+	const auto launchIndex = getLaunchIndex();
+	if (launchIndex.x >= sysData.resolution.x || launchIndex.y >= sysData.resolution.y) return;
+	
+	const unsigned int index = launchIndex.y * sysData.resolution.x + launchIndex.x; // Pixel index
 	const auto buffer = reinterpret_cast<float4*>(sysData.outputBuffer);
 	
-	const float3 radiance = lastThroughput[index] * lastRadiance[index];
-	//const float3 radiance = lastThroughput[index];
-	//const float3 radiance = lastRadiance[index];
+	// Make sure endRenderRadiance doesn't contain garbage here.
+	//const float3 radiance = endRenderThroughput[index] * endRenderRadiance[index];
+	const float3 radiance = endRenderThroughput[index] * make_float3(1.0f);
+	//const float3 radiance = endRenderRadiance[index];
 	const float accWeight = 1.0f / float(sysData.pf.iterationIndex + 1);
 	
 	float3 dst = make_float3(buffer[index]);
 	dst += (radiance * accWeight);	
 	buffer[index] = make_float4(dst, 1.0f);
+}
+
+extern "C" __global__ void propagate_train_radiance(nrc::TrainingSuffixEndVertex *trainSuffixEndVertices, // [:#tiles]
+													float3 *endTrainRadiance, // [:#tiles]
+													nrc::TrainingRecord *trainRecords, // [65536]
+													float3 *trainRadianceTargets) // [65536]
+{
+	const auto launchIndex = getLaunchIndex();
+	if (launchIndex.x >= sysData.pf.numTiles.x || launchIndex.y >= sysData.pf.numTiles.y) return;
+
+	const unsigned int tileIndex = launchIndex.y * sysData.pf.numTiles.x + launchIndex.x; // Tile index
+	
+	const auto &endVert = trainSuffixEndVertices[tileIndex];
+	float3 lastRadiance = endTrainRadiance[tileIndex] * endVert.radianceMask;
+
+	int iTo = endVert.startTrainRecord;
+#if 1
+	if (iTo >= sysData.nrcCB->numTrainingRecords || !(endVert.radianceMask == 0.f || endVert.radianceMask == 1.f))
+	{
+		printf("[Tile %d/%d] Invalid end vertex: startTrainRecord(int) = %d (/%d). radianceMask(float) = %f\n", 
+			   tileIndex+1, sysData.pf.numTiles.x * sysData.pf.numTiles.y, iTo, sysData.nrcCB->numTrainingRecords, endVert.radianceMask);
+		return;
+	}
+#endif
+	while (iTo >= 0)
+	{
+		//if (launchIndex.x == sysData.pf.numTiles.x / 2 && launchIndex.y == sysData.pf.numTiles.y / 2)
+		//	printf("%d->", iTo);
+
+		auto &recordTo   = trainRecords[iTo];
+		auto &radianceTo = trainRadianceTargets[iTo];
+		
+		radianceTo += recordTo.localThroughput * lastRadiance;
+		
+		// Go to next record
+		lastRadiance = radianceTo;
+		iTo = recordTo.propTo;
+	}
+	//if (launchIndex.x == sysData.pf.numTiles.x / 2 && launchIndex.y == sysData.pf.numTiles.y / 2)
+	//	printf("[END]\n");
 }

--- a/apps/neural_radiance_caching_mdl/shaders/raygeneration.cu
+++ b/apps/neural_radiance_caching_mdl/shaders/raygeneration.cu
@@ -490,16 +490,22 @@ __forceinline__ __device__ int tileIndex(const uint2& launchIndex)
 {
 	const auto tileIndexX = launchIndex.x / sysData.pf.tileSize.x;
 	const auto tileIndexY = launchIndex.y / sysData.pf.tileSize.y;
-	const auto numTilesX = sysData.resolution.x / sysData.pf.tileSize.x;
 
-	return tileIndexY * numTilesX + tileIndexX;
+	return tileIndexY * sysData.pf.numTiles.x + tileIndexX;
+}
+
+__forceinline__ __device__ bool isBoundaryRay(const uint2& launchIndex)
+{
+	const auto xEnd = sysData.pf.numTiles.x * sysData.pf.tileSize.x;
+	const auto yEnd = sysData.pf.numTiles.y * sysData.pf.tileSize.y;
+
+	return (launchIndex.x >= xEnd || launchIndex.y >= yEnd);
 }
 
 __forceinline__ __device__ bool isTrainingRay(const uint2& launchIndex)
 {
 	// Discard boundary tile
-	if (launchIndex.x + sysData.pf.tileSize.x > sysData.resolution.x ||
-		launchIndex.y + sysData.pf.tileSize.y > sysData.resolution.y)
+	if (isBoundaryRay(launchIndex))
 	{
 		return false;
 	}

--- a/apps/neural_radiance_caching_mdl/shaders/raygeneration.cu
+++ b/apps/neural_radiance_caching_mdl/shaders/raygeneration.cu
@@ -104,6 +104,8 @@ __forceinline__ __device__ void sampleVolumeScattering(const float2 xi, const fl
 	dir = tbn.transformToWorld(d);
 }
 
+#if 0
+
 __forceinline__ __device__ float3 integrator(PerRayData& prd)
 {
 	// The integrator starts with black radiance and full path throughput.
@@ -480,6 +482,7 @@ extern "C" __global__ void __raygen__path_tracer()
 #endif // USE_FP32_OUTPUT
 	}
 }
+#endif
 
 namespace {
 
@@ -782,7 +785,7 @@ extern "C" __global__ void __raygen__nrc_path_tracer()
 		}
 		buffer[index] = result;
 #else // if !USE_TIME_VIEW
-		//if (sysData.pf.iterationIndex > 0)
+		if (sysData.pf.iterationIndex > 0)
 		{
 			const float3 dst = make_float3(buffer[index]); // RGB24F
 			radiance = lerp(dst, radiance, 1.0f / float(sysData.pf.iterationIndex + 1)); // Only accumulate the radiance, alpha stays 1.0f.

--- a/apps/neural_radiance_caching_mdl/shaders/system_data.h
+++ b/apps/neural_radiance_caching_mdl/shaders/system_data.h
@@ -58,8 +58,9 @@ struct SystemDataPerFrame
 	// 16 byte alignment
 
 	// 8 byte alignment
-	int2 tileSize = { 8, 8 };    // Example: make_int2(8, 4) for 8x4 tiles. Must be a power of two to make the division a right-shift.
+	int2 tileSize{ 8, 8 };    // Example: make_int2(8, 4) for 8x4 tiles. Must be a power of two to make the division a right-shift.
 	//int2 tileShift;   // Example: make_int2(3, 2) for the integer division by tile size. That actually makes the tileSize redundant. 
+	int2 numTiles{ 0, 0 }; // Screen resolution / tileSize
 
 	// 4 byte alignment
 	int iterationIndex;

--- a/apps/neural_radiance_caching_mdl/src/Application.cpp
+++ b/apps/neural_radiance_caching_mdl/src/Application.cpp
@@ -719,8 +719,8 @@ void Application::guiWindow()
 		if (ImGui::Button("Match Resolution"))
 		{
 			// Match the rendering resolution to the current client window size.
-			m_resolution.x = std::max(1, m_width);
-			m_resolution.y = std::max(1, m_height);
+			m_resolution.x = std::max(2, m_width);
+			m_resolution.y = std::max(2, m_height);
 
 			m_camera.setResolution(m_resolution.x, m_resolution.y);
 			m_rasterizer->setResolution(m_resolution.x, m_resolution.y);
@@ -730,8 +730,8 @@ void Application::guiWindow()
 		}
 		if (ImGui::InputInt2("Resolution", &m_resolution.x, ImGuiInputTextFlags_EnterReturnsTrue)) // This requires RETURN to apply a new value.
 		{
-			m_resolution.x = std::max(1, m_resolution.x);
-			m_resolution.y = std::max(1, m_resolution.y);
+			m_resolution.x = std::max(2, m_resolution.x);
+			m_resolution.y = std::max(2, m_resolution.y);
 
 			m_camera.setResolution(m_resolution.x, m_resolution.y);
 			m_rasterizer->setResolution(m_resolution.x, m_resolution.y);


### PR DESCRIPTION
Fixes bugs in:
- Discarding boundary rays that caused training rays to be less than there should be.
- Allocating more memory for dynamic NRC buffers than actually needed.
Edit:
- Made minimum resolution to be 2x2, matching the min. tile size we assumed. Previously NRC buffer allcation could error due size being 0.