### PR TITLE
major fix: offset into inference radiance queries

### DIFF
--- a/apps/neural_radiance_caching_mdl/inc/NRCNetworkConfigs.h
+++ b/apps/neural_radiance_caching_mdl/inc/NRCNetworkConfigs.h
@@ -27,6 +27,7 @@ namespace cfg {
 				//{"learning_rate", 0.0f},
 				//{"beta1", 0.9f},
 				//{"beta2", 0.99f},
+				{"l2_reg", 0.0f},
 				//{"epsilon", 1e-8f},
 			}}
 		}},

--- a/apps/neural_radiance_caching_mdl/shaders/hit.cu
+++ b/apps/neural_radiance_caching_mdl/shaders/hit.cu
@@ -618,7 +618,8 @@ __forceinline__ __device__ void endTrainSuffixSelfTrain(const Mdl_state& mdlStat
     auto& dynBufs = sysData.nrcCB->bufDynamic;
 
 	// Add an inference query at the end vertex of the train suffix.
-	auto& query = dynBufs.radianceQueriesInference[NUM_TRAINING_RECORDS_PER_FRAME + thePrd.tileIndex];
+    const auto offset = sysData.resolution.x * sysData.resolution.y;
+	auto& query = dynBufs.radianceQueriesInference[offset + thePrd.tileIndex];
 	addQuery(mdlState, thePrd, auxData, query);
 
 	// Add the TrainingSuffixEndVertex
@@ -634,7 +635,8 @@ __forceinline__ __device__ void endTrainSuffixSelfTrain(const Mdl_state& mdlStat
 __forceinline__ __device__ void endTrainSuffixUnbiased(const PerRayData& thePrd)
 {
     // Just leave the stale query there - we will mask off the inferenced result with endVertex.radianceMask = 0
-    //auto& query = sysData.nrcCB->radianceQueriesInference[NUM_TRAINING_RECORDS_PER_FRAME + thePrd.tileIndex];
+    //const auto offset = sysData.resolution.x * sysData.resolution.y;
+    //auto& query = sysData.nrcCB->radianceQueriesInference[offset + thePrd.tileIndex];
     //addQuery(mdlState, thePrd, auxData, query);
 
     // Add the TrainingSuffixEndVertex

--- a/apps/neural_radiance_caching_mdl/shaders/miss.cu
+++ b/apps/neural_radiance_caching_mdl/shaders/miss.cu
@@ -44,7 +44,8 @@ namespace nrc {
 __forceinline__ __device__ void endTrainSuffixUnbiased(const PerRayData& thePrd)
 {
 	// Just leave the stale query there - we will mask off the inferenced result with endVertex.radianceMask = 0
-	//auto& query = sysData.nrcCB->radianceQueriesInference[NUM_TRAINING_RECORDS_PER_FRAME + thePrd.tileIndex];
+	//const auto offset = sysData.resolution.x * sysData.resolution.y;
+	//auto& query = sysData.nrcCB->radianceQueriesInference[offset + thePrd.tileIndex];
 	//addQuery(mdlState, thePrd, auxData, query);
 
 	// Add the TrainingSuffixEndVertex
@@ -57,7 +58,7 @@ __forceinline__ __device__ void endTrainSuffixUnbiased(const PerRayData& thePrd)
 	//endVertex.tileIndex = thePrd.tileIndex;
 }
 
-__forceinline__ __device__ void addNullRenderQuey(const PerRayData& thePrd)
+[[maybe_unused]] __forceinline__ __device__ void addNullRenderQuey(const PerRayData& thePrd)
 {
 	auto& renderQuery = sysData.nrcCB->bufDynamic.radianceQueriesInference[thePrd.pixelIndex];
 	renderQuery = nrc::RadianceQuery{};
@@ -107,7 +108,8 @@ extern "C" __global__ void __miss__env_null()
 	{
 		thePrd->lastRenderThroughput = make_float3(0.f);
 
-		// Not strictly needed, because lastRenderThroughput is 0
+		// Add a null query to aid debugging. 
+		// Not strictly needed, because lastRenderThroughput is 0.
 		nrc::addNullRenderQuey(*thePrd);
 	}
 
@@ -167,7 +169,8 @@ extern "C" __global__ void __miss__env_constant()
 		// been accounted for by Direct Lighting. Avoid double counting!
 		thePrd->lastRenderThroughput = make_float3(0.f);
 
-		// Not strictly needed, because lastRenderThroughput is 0
+		// Add a null query to aid debugging. 
+		// Not strictly needed, because lastRenderThroughput is 0.
 		nrc::addNullRenderQuey(*thePrd);
 	}
 
@@ -240,7 +243,8 @@ extern "C" __global__ void __miss__env_sphere()
 		// been accounted for by Direct Lighting. Avoid double counting!
 		thePrd->lastRenderThroughput = make_float3(0.f);
 
-		// Not strictly needed, because lastRenderThroughput is 0
+		// Add a null query to aid debugging. 
+		// Not strictly needed, because lastRenderThroughput is 0.
 		nrc::addNullRenderQuey(*thePrd);
 	}
 

--- a/apps/neural_radiance_caching_mdl/shaders/nrc_helpers.cu
+++ b/apps/neural_radiance_caching_mdl/shaders/nrc_helpers.cu
@@ -111,11 +111,11 @@ extern "C" __global__ void propagate_train_radiance(nrc::TrainingSuffixEndVertex
 	// DEBUG: SUPER BLUE if no prop happens
 	//if (iTo < 0) { debug_fill_tile({ 0.f, 0.f, 100000.f }, launchIndex); return; }
 	
-	[[maybe_unused]] float3 secondToLastRadiance = lastRadiance;
+	//[[maybe_unused]] float3 secondToLastRadiance = lastRadiance;
 
 	while (iTo >= 0)
 	{
-		secondToLastRadiance = lastRadiance;
+		//secondToLastRadiance = lastRadiance;
 
 		//if (launchIndex.x == sysData.pf.numTiles.x / 2 && launchIndex.y == sysData.pf.numTiles.y / 2)
 		//	printf("%d->", iTo);

--- a/apps/neural_radiance_caching_mdl/shaders/raygeneration.cu
+++ b/apps/neural_radiance_caching_mdl/shaders/raygeneration.cu
@@ -489,7 +489,8 @@ namespace nrc {
 __forceinline__ __device__ void endTrainSuffixUnbiased(const PerRayData& thePrd)
 {
 	// Just leave the stale query there - we will mask off the inferenced result with endVertex.radianceMask = 0
-	//auto& query = sysData.nrcCB->radianceQueriesInference[NUM_TRAINING_RECORDS_PER_FRAME + thePrd.tileIndex];
+	//const auto offset = sysData.resolution.x * sysData.resolution.y;
+	//auto& query = sysData.nrcCB->radianceQueriesInference[offset + thePrd.tileIndex];
 	//addQuery(mdlState, thePrd, auxData, query);
 
 	// Add the TrainingSuffixEndVertex

--- a/apps/neural_radiance_caching_mdl/src/Device.cpp
+++ b/apps/neural_radiance_caching_mdl/src/Device.cpp
@@ -2020,7 +2020,7 @@ void Device::render(const unsigned int iterationIndex,
 		{
 			const auto scale = static_cast<float>(screenSize) / static_cast<float>(m_bufferHost.size());
 			adjustTileSize(m_nrcControlBlock.numTrainingRecords * scale);
-			std::cout << "[HOST] Tile size adjusted to: " << m_systemData.pf.tileSize.x << ',' << m_systemData.pf.tileSize.y << "after screen resize\n";
+			//std::cout << "[HOST] Tile size adjusted to: " << m_systemData.pf.tileSize.x << ',' << m_systemData.pf.tileSize.y << "after screen resize\n";
 		}
 
 		MY_ASSERT(buffer != nullptr);
@@ -2159,7 +2159,7 @@ void Device::render(const unsigned int iterationIndex,
 	// Note the launch width per device to render in tiles.
 	//if (totalSubframeIndex < 2) // DEBUG
 	OPTIX_CHECK(m_api.optixLaunch(m_pipeline, m_cudaStream, reinterpret_cast<CUdeviceptr>(m_d_systemData), sizeof(SystemData), 
-								&m_sbt, m_launchWidth, m_systemData.resolution.y, /* depth */ 1));
+								  &m_sbt, m_launchWidth, m_systemData.resolution.y, /* depth */ 1));
 
 	// Sync with Device the per-frame data of the NRC block (currently just numTrainingRecords)
 	CU_CHECK(cuMemcpyDtoHAsync(&m_nrcControlBlock.numTrainingRecords, 
@@ -2324,14 +2324,6 @@ void Device::render(const unsigned int iterationIndex,
 
 		CU_CHECK(cuLaunchKernelEx(&cfg, m_fnPermuteTrainData, args, nullptr));
 		}
-
-		//// DEBUG: Set all targets to a hard-coded value
-		//float fval = 0.5f;
-		//unsigned int valp = *reinterpret_cast<unsigned int*>(&fval);
-		//CU_CHECK(cuMemsetD32Async(reinterpret_cast<CUdeviceptr>(targetsShuffleDst), 
-		//			valp,
-		//			nrc::NUM_TRAINING_RECORDS_PER_FRAME * 3ull,
-		//			m_cudaStream));
 
 		// At this point, all training data is ready
 		const auto queriesShuffled = m_nrcControlBlock.bufStatic.radianceQueriesTraining.getBuffer(1);


### PR DESCRIPTION
In hit.cu, the queries at train suffix for self-training should start at `radianceQueriesInference[numPixels]` instead of `radianceQueriesInference[NUM_TRAINING_RECORDS_PER_FRAME]`